### PR TITLE
Manage border cases (#26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ The request returns code `200` upon success. The return `json` will look like:
       "found": false,
       "found_date": null,
       "id": 1,
-      "key_digest": "$2b$12$qaWmfu.nG2Akb/sLoLdrj.wid6DM0i55zTHFI36UH.r4G..rv8SjK",
       "last_name": "Martínez",
       "name": "Ariel"
     },
@@ -69,7 +68,6 @@ The request returns code `200` upon success. The return `json` will look like:
       "found": false,
       "found_date": null,
       "id": 3,
-      "key_digest": "$2b$12$NyknKBZurcmen1gYV0V3OuPzDm2gOjsvS2SoY5J03zRVjXcmm0d5a",
       "last_name": "Leal",
       "name": "Daniel"
     },
@@ -78,7 +76,6 @@ The request returns code `200` upon success. The return `json` will look like:
       "found": false,
       "found_date": null,
       "id": 27,
-      "key_digest": "$2b$12$Xir8RZtDwq2vW4Bp7Iw/S.TGpu0g6N0KkmIJ.eeOlYM7y.vUwXi4K",
       "last_name": "Irarrázaval",
       "name": "Alfonso"
     }
@@ -137,7 +134,6 @@ The request returns code `200` upon success. The return `json` will look like:
       "found": true,
       "found_date": "Wed, 23 Oct 2019 04:37:21 GMT",
       "id": 1,
-      "key_digest": "$2b$12$qaWmfu.nG2Akb/sLoLdrj.wid6DM0i55zTHFI36UH.r4G..rv8SjK",
       "last_name": "Martínez",
       "name": "Ariel"
     },
@@ -146,7 +142,6 @@ The request returns code `200` upon success. The return `json` will look like:
       "found": true,
       "found_date": "Wed, 23 Oct 2019 06:17:02 GMT",
       "id": 3,
-      "key_digest": "$2b$12$NyknKBZurcmen1gYV0V3OuPzDm2gOjsvS2SoY5J03zRVjXcmm0d5a",
       "last_name": "Leal",
       "name": "Daniel"
     }
@@ -170,21 +165,26 @@ The request returns code `200` upon success. The return `json` will look like:
 
 #### Response
 
+If the request fails (it may fail because :first_name or :last_name are empty strings or strings containing only whitespaces (code `400`) or because either mail does not match the `regex` expression (code `400`)), the `json` will look like:
+
+```json
+{
+  "payload": "Generic message detailing the failure",
+  "success": false
+}
+```
+
 The request returns code `200` upon success. The return `json` will look like:
 
 ```json
 {
   "payload": {
-    "person": {
-      "created_date": "Wed, 23 Oct 2019 05:31:06 GMT",
-      "found": false,
-      "found_date": null,
-      "id": 8,
-      "key_digest": "$2b$12$uTCD1kGChKsP0OU7MAz3NuIPoMcBDXTNNnua9zzM4DbaEox4g87mG",
-      "last_name": "Leal",
-      "name": "Daniel"
-    },
-    "plain_key": "brxmDs9U6cG56N8K",
+    "created_date": "Wed, 23 Oct 2019 05:31:06 GMT",
+    "found": false,
+    "found_date": null,
+    "id": 8,
+    "last_name": "Leal",
+    "name": "Daniel"
   },
   "success": true
 }
@@ -216,7 +216,6 @@ The request returns code `200` upon success. The return `json` will look like:
     "found": false,
     "found_date": null,
     "id": 7,
-    "key_digest": "$2b$12$Xir8RZtDwq2vW4Bp7Iw/S.TGpu0g6N0KkmIJ.eeOlYM7y.vUwXi4K",
     "last_name": "Leal",
     "name": "Daniel"
   },

--- a/custom_exceptions.py
+++ b/custom_exceptions.py
@@ -1,0 +1,16 @@
+class EmptyNameError(Exception):
+
+    """Exception for when an empty name is given to a new person creator."""
+
+    def __init__(self):
+        message = 'EmptyNameError: Cannot parse an empty name'
+        super().__init__(message)
+
+
+class InvalidMailError(Exception):
+
+    """Exception for when a mail does not match with the mail regex."""
+
+    def __init__(self, invalid_mail):
+        message = f'InvalidMailError: Invalid mail format: {invalid_mail}'
+        super().__init__(message)

--- a/person.py
+++ b/person.py
@@ -55,7 +55,6 @@ class Person(db.Model):
             'id': self.id,
             'name': self.first_name,
             'last_name': self.last_name,
-            'key_digest': self.key_digest,
             'found': self.found,
             'created_date': self.created_date,
             'found_date': self.found_date


### PR DESCRIPTION
* Now the create person endpoint does not return the plain text key

* Now the person serialization does not return the key digest

* Now the README does not show the digest of every key

* Added some custom exceptions to catch user input errors

* Now upon creation of a new user the API will check that first name and last name are not empty strings and that the mail is a valid mail

* Extended user creation documentation to document user input error failures